### PR TITLE
Add 'Code:' section comment

### DIFF
--- a/leerzeichen.el
+++ b/leerzeichen.el
@@ -31,6 +31,8 @@
 
 ;; More information: https://github.com/fgeller/leerzeichen.el/
 
+;;; Code:
+
 (defgroup leerzeichen nil
   "Faces for highlighting whitespace characters."
   :group 'leerzeichen)


### PR DESCRIPTION
This package did not have `Code:` comment so that `Description` of `http://melpa.org/#/leerzeichen` contains code part.